### PR TITLE
feat: add shared proto package

### DIFF
--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@proto/shared",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -w -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json",
+    "lint": "echo 'no lint configured in proto yet'"
+  }
+}

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./schemas";

--- a/packages/proto/src/schemas.ts
+++ b/packages/proto/src/schemas.ts
@@ -1,0 +1,24 @@
+export interface User {
+  id: string;
+  displayName: string;
+  avatarUrl?: string;
+}
+
+export interface Room {
+  id: string;
+  hostId: string;
+  mode: "mesh" | "sfu";
+  createdAt: string; // ISO
+  locked?: boolean;
+}
+
+export interface TurnCredential {
+  username: string;
+  credential: string;
+  expiresAt: number;
+}
+
+export interface JoinRoomResponse {
+  roomToken: string;
+  iceServers: Array<{ urls: string | string[]; username?: string; credential?: string }>;
+}

--- a/packages/proto/tsconfig.json
+++ b/packages/proto/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a proto package that exports shared TypeScript schema definitions
- configure build tooling for the proto package with tsconfig and scripts

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dfe02be7d08333bccdea831e984175