### PR TITLE
Add docker-compose scaffolding for Redis and coturn services

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  # TURN server placeholder (configure later with secrets)
+  coturn:
+    image: instrumentisto/coturn
+    command: >
+      -n --log-file=stdout
+      --listening-port=3478
+      --fingerprint
+      --lt-cred-mech
+      --realm=example.com
+      --no-cli
+    environment:
+      - TURN_USERNAME=demo
+      - TURN_PASSWORD=demo
+    ports:
+      - "3478:3478/udp"
+      - "3478:3478/tcp"


### PR DESCRIPTION
## Summary
- add an infra docker-compose file configuring Redis and a coturn placeholder

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfe25f043c8333a50c6bbcd5685e60