### PR TITLE
feat: scaffold signaling node service

### DIFF
--- a/apps/signaling/.env.example
+++ b/apps/signaling/.env.example
@@ -1,0 +1,7 @@
+PORT=8080
+JWT_SECRET=change_me
+REDIS_URL=redis://localhost:6379
+TURN_REALM=example.com
+TURN_API_KEY=local-demo
+TURN_STATIC_USERNAME=demo
+TURN_STATIC_CREDENTIAL=demo

--- a/apps/signaling/package.json
+++ b/apps/signaling/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@apps/signaling",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "typecheck": "tsc -p tsconfig.json",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "http-status-codes": "^2.3.0",
+    "ioredis": "^5.4.1",
+    "jsonwebtoken": "^9.0.2",
+    "socket.io": "^4.7.5",
+    "zod": "^3.23.8",
+    "@proto/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.6",
+    "@types/node": "^20.14.12",
+    "eslint": "^9.9.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/signaling/src/index.ts
+++ b/apps/signaling/src/index.ts
@@ -1,0 +1,72 @@
+import "dotenv/config";
+import express from "express";
+import http from "http";
+import cors from "cors";
+import { Server } from "socket.io";
+import { StatusCodes } from "http-status-codes";
+import Redis from "ioredis";
+import jwt from "jsonwebtoken";
+import { getTurnCredentials } from "./turn.js";
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: "*" } });
+
+const redis = new Redis(process.env.REDIS_URL);
+
+app.get("/health", (_req, res) => res.status(StatusCodes.OK).json({ ok: true }));
+app.post("/turn-cred", getTurnCredentials);
+
+// (stub) Create room
+app.post("/v1/rooms", (req, res) => {
+  const { hostId, mode } = req.body ?? {};
+  const id = "room_" + Math.random().toString(36).slice(2, 10);
+  const room = { id, hostId, mode: mode ?? "mesh", createdAt: new Date().toISOString() };
+  redis.set(`room:${id}`, JSON.stringify(room));
+  const token = jwt.sign({ roomId: id, role: "host" }, process.env.JWT_SECRET!, { expiresIn: "2h" });
+  res.json({ room, token });
+});
+
+// (stub) Join room
+app.post("/v1/rooms/:id/join", async (req, res) => {
+  const roomId = req.params.id;
+  const room = await redis.get(`room:${roomId}`);
+  if (!room) return res.status(StatusCodes.NOT_FOUND).json({ error: "room not found" });
+  const token = jwt.sign({ roomId, role: "participant" }, process.env.JWT_SECRET!, { expiresIn: "2h" });
+  res.json({ token });
+});
+
+// Socket.IO signaling events
+io.on("connection", (socket) => {
+  socket.on("joinRoom", async ({ roomId, userId }) => {
+    socket.join(roomId);
+    io.to(roomId).emit("participantJoined", { userId, socketId: socket.id });
+  });
+
+  socket.on("signal", ({ roomId, from, to, data }) => {
+    if (to) {
+      io.to(to).emit("signal", { from, data }); // direct
+    } else {
+      socket.to(roomId).emit("signal", { from, data }); // broadcast
+    }
+  });
+
+  socket.on("mute", ({ roomId, userId, muted }) => {
+    socket.to(roomId).emit("mute", { userId, muted });
+  });
+
+  socket.on("videoToggle", ({ roomId, userId, enabled }) => {
+    socket.to(roomId).emit("videoToggle", { userId, enabled });
+  });
+
+  socket.on("leaveRoom", ({ roomId, userId }) => {
+    socket.leave(roomId);
+    socket.to(roomId).emit("participantLeft", { userId, socketId: socket.id });
+  });
+});
+
+const port = Number(process.env.PORT) || 8080;
+server.listen(port, () => console.log(`signaling listening on :${port}`));

--- a/apps/signaling/src/turn.ts
+++ b/apps/signaling/src/turn.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from "express";
+
+export const getTurnCredentials = async (_req: Request, res: Response) => {
+  // For now, return static TURN creds (replace with dynamic/temporary).
+  const iceServers = [
+    { urls: ["stun:stun.l.google.com:19302"] },
+    {
+      urls: ["turn:localhost:3478?transport=udp", "turn:localhost:3478?transport=tcp"],
+      username: process.env.TURN_STATIC_USERNAME || "demo",
+      credential: process.env.TURN_STATIC_CREDENTIAL || "demo"
+    }
+  ];
+  res.json({ iceServers });
+};

--- a/apps/signaling/src/types.ts
+++ b/apps/signaling/src/types.ts
@@ -1,0 +1,1 @@
+export type RoomMode = "mesh" | "sfu";

--- a/apps/signaling/tsconfig.json
+++ b/apps/signaling/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@proto/shared": ["../../packages/proto/src"]
+    }
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add package configuration for the signaling service
- scaffold express and socket.io server entry point with TURN endpoint
- provide sample environment variables and shared TypeScript configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe31bfb208333831fcf5103b8137e