### PR TITLE
feat(mobile): bootstrap flutter app with signaling client

### DIFF
--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,0 +1,43 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Visual Studio Code related
+.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+dsym/
+
+# Obfuscation related
+app.*.symbols
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release
+

--- a/apps/mobile/analysis_options.yaml
+++ b/apps/mobile/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/apps/mobile/lib/env.dart
+++ b/apps/mobile/lib/env.dart
@@ -1,0 +1,4 @@
+class Env {
+  static const signalingBase =
+      String.fromEnvironment('SIGNALING_BASE', defaultValue: 'http://localhost:8080');
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,0 +1,168 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'env.dart';
+import 'webrtc/signaling_client.dart';
+
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+final signalingClientProvider = Provider<SignalingClient>((ref) {
+  return SignalingClient(Env.signalingBase);
+});
+
+final lastMessageProvider = StateProvider<String?>((ref) => null);
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Car Connect',
+      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue), useMaterial3: true),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends ConsumerStatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  ConsumerState<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends ConsumerState<HomePage> {
+  final TextEditingController _hostController = TextEditingController(text: 'host-1');
+  final TextEditingController _roomController = TextEditingController();
+
+  @override
+  void dispose() {
+    _hostController.dispose();
+    _roomController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _createRoom() async {
+    final client = ref.read(signalingClientProvider);
+    final notifier = ref.read(lastMessageProvider.notifier);
+    try {
+      final response = await client.createRoom(_hostController.text);
+      final message = 'Created room: ${jsonEncode(response)}';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+      _roomController.text = response['id']?.toString() ?? _roomController.text;
+    } catch (error, stackTrace) {
+      final message = 'Failed to create room: $error';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+      // ignore: avoid_print
+      print(stackTrace);
+    }
+  }
+
+  Future<void> _joinRoom() async {
+    final client = ref.read(signalingClientProvider);
+    final notifier = ref.read(lastMessageProvider.notifier);
+    try {
+      final response = await client.joinRoom(_roomController.text);
+      final message = 'Joined room: ${jsonEncode(response)}';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+    } catch (error, stackTrace) {
+      final message = 'Failed to join room: $error';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+      // ignore: avoid_print
+      print(stackTrace);
+    }
+  }
+
+  Future<void> _fetchTurnCredentials() async {
+    final client = ref.read(signalingClientProvider);
+    final notifier = ref.read(lastMessageProvider.notifier);
+    try {
+      final response = await client.turnCred();
+      final message = 'Fetched TURN credentials: ${jsonEncode(response)}';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+    } catch (error, stackTrace) {
+      final message = 'Failed to fetch TURN credentials: $error';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+      // ignore: avoid_print
+      print(stackTrace);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lastMessage = ref.watch(lastMessageProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Car Connect Signaling'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _hostController,
+              decoration: const InputDecoration(labelText: 'Host ID'),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _createRoom,
+                    child: const Text('Create Room'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _fetchTurnCredentials,
+                    child: const Text('Get TURN Creds'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            TextField(
+              controller: _roomController,
+              decoration: const InputDecoration(labelText: 'Room ID'),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _joinRoom,
+                child: const Text('Join Room'),
+              ),
+            ),
+            const SizedBox(height: 24),
+            if (lastMessage != null) ...[
+              const Text('Last message:'),
+              const SizedBox(height: 8),
+              Text(lastMessage),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/webrtc/signaling_client.dart
+++ b/apps/mobile/lib/webrtc/signaling_client.dart
@@ -1,0 +1,23 @@
+import 'package:dio/dio.dart';
+
+class SignalingClient {
+  final Dio _dio = Dio(BaseOptions(connectTimeout: const Duration(seconds: 5)));
+  final String base;
+
+  SignalingClient(this.base);
+
+  Future<Map<String, dynamic>> createRoom(String hostId, {String mode = 'mesh'}) async {
+    final res = await _dio.post('$base/v1/rooms', data: {'hostId': hostId, 'mode': mode});
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<Map<String, dynamic>> joinRoom(String roomId) async {
+    final res = await _dio.post('$base/v1/rooms/$roomId/join');
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<Map<String, dynamic>> turnCred() async {
+    final res = await _dio.post('$base/turn-cred');
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -1,0 +1,23 @@
+name: mobile
+description: A new Flutter project.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_webrtc: ^0.11.7
+  permission_handler: ^11.3.1
+  dio: ^5.7.0
+  flutter_riverpod: ^2.5.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a Flutter mobile application skeleton under apps/mobile with lint configuration
- provide environment configuration and a Dio-based signaling client for REST calls
- implement a Riverpod-powered home screen that can create or join rooms and fetch TURN credentials

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfe3c9ce608333b07719599e9c1686