### PR TITLE
feat: add admin next.js app

### DIFF
--- a/apps/admin/.env.local.example
+++ b/apps/admin/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SIGNALING_BASE=http://localhost:8080

--- a/apps/admin/.eslintrc.json
+++ b/apps/admin/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/.next
+/out
+/.turbo
+.env.local

--- a/apps/admin/app/calls/page.tsx
+++ b/apps/admin/app/calls/page.tsx
@@ -1,0 +1,21 @@
+const activeRooms: Array<{ id: string; title: string }> = [
+  { id: "room-1", title: "Demo Room 1" },
+  { id: "room-2", title: "Demo Room 2" },
+];
+
+export default function CallsPage() {
+  return (
+    <main>
+      <h1>Active Calls</h1>
+      <p>Rooms fetched from the signaling service will appear here.</p>
+      <ul>
+        {activeRooms.map((room) => (
+          <li key={room.id}>
+            <strong>{room.title}</strong>
+            <div>ID: {room.id}</div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1,0 +1,21 @@
+:root {
+  color-scheme: light;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: #f5f5f5;
+  color: #111;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+}

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Car Connect Admin",
+  description: "Admin dashboard for Car Connect",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/admin/app/page.tsx
+++ b/apps/admin/app/page.tsx
@@ -1,0 +1,8 @@
+export default function DashboardPage() {
+  return (
+    <main>
+      <h1>Admin Dashboard</h1>
+      <p>This is a placeholder for the future dashboard experience.</p>
+    </main>
+  );
+}

--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "admin",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.56",
+    "@types/react-dom": "18.2.19",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.3.3"
+  }
+}

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a minimal Next.js (TypeScript) admin application under `apps/admin`
- add placeholder dashboard and calls routes using the App Router
- provide project scripts and example environment configuration

## Testing
- not run (pnpm install unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfee4e59f88333a8ce1a3e8d4538ac