### PR TITLE
Add root scripts and docs for local environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Root env reference
+SIGNALING_PORT=8080
+REDIS_URL=redis://localhost:6379

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Thumbs.db
 # Env
 .env
 .env.*
+!.env.example
 
 # Misc
 .idea/

--- a/apps/signaling/README.md
+++ b/apps/signaling/README.md
@@ -1,3 +1,25 @@
 # Car-Connect Signaling Service
 
 Node.js/Express signaling API using Socket.IO for WebRTC coordination.
+
+## Local Development
+
+```bash
+pnpm dev
+docker compose up redis coturn
+```
+
+## HTTP Endpoints
+
+- `GET /health`
+- `POST /v1/rooms`
+- `POST /v1/rooms/:id/join`
+- `GET /turn-cred`
+
+## Socket.IO Events
+
+- `joinRoom`
+- `signal`
+- `mute`
+- `videoToggle`
+- `leaveRoom`

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "packageManager": "pnpm@8.15.4",
   "scripts": {
-    "postinstall": "pnpm install --recursive"
+    "build": "pnpm -r build",
+    "dev": "pnpm -r --parallel dev",
+    "dev:stack": "docker compose -f infra/docker-compose.yml up --remove-orphans",
+    "dev:signaling": "pnpm --filter @apps/signaling dev",
+    "dev:admin": "pnpm --filter admin dev",
+    "typecheck": "pnpm -r typecheck",
+    "format": "prettier -w ."
   }
 }


### PR DESCRIPTION
## Summary
- add convenient root scripts for building, developing, and formatting the monorepo
- document required environment variables in a tracked `.env.example`
- update the signaling service README with local setup guidance and available endpoints/events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfef99363083339ea8924fe1bb309f