### PR TITLE
docs: add local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,28 @@ This repository is organized as a pnpm-based monorepo that groups the mobile cli
 ```
 
 Each directory currently contains placeholder files and can be expanded with application-specific code as the project evolves.
+
+## Local Dev
+
+### Terminal A: Infra
+
+```bash
+pnpm dev:stack    # starts redis + coturn
+```
+
+### Terminal B: Signaling API
+
+```bash
+cp apps/signaling/.env.example apps/signaling/.env
+pnpm dev:signaling
+```
+
+### Terminal C: Flutter Mobile (run emulator or real device)
+
+```bash
+cd apps/mobile
+flutter pub get
+flutter run -d <your_device>  # ensure signalingBase points to your machine IP
+```
+
+> **Note:** On-device testing requires replacing `http://localhost:8080` with your host LAN IP in `Env.signalingBase`, or passing `--dart-define=SIGNALING_BASE="http://<LAN_IP>:8080"` when launching the Flutter app.


### PR DESCRIPTION
## Summary
- add local development steps covering infra, signaling API, and Flutter mobile setup
- document LAN IP configuration note for on-device testing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dff6f263f8833388e6a1667bea6c7b