### PR TITLE
Add auth utilities and redis helpers for signaling service

### DIFF
--- a/apps/signaling/src/auth.ts
+++ b/apps/signaling/src/auth.ts
@@ -1,0 +1,28 @@
+import jwt from "jsonwebtoken";
+import { Request, Response, NextFunction } from "express";
+
+export interface AuthPayload {
+  roomId?: string;
+  role?: "host" | "participant";
+  userId?: string;
+}
+
+export function signToken(payload: AuthPayload, ttl = "2h") {
+  return jwt.sign(payload, process.env.JWT_SECRET!, { expiresIn: ttl });
+}
+
+export function verifyToken<T = AuthPayload>(token: string): T {
+  return jwt.verify(token, process.env.JWT_SECRET!) as T;
+}
+
+export function requireBearer(req: Request, res: Response, next: NextFunction) {
+  const hdr = req.headers.authorization || "";
+  const m = hdr.match(/^Bearer\s+(.+)$/i);
+  if (!m) return res.status(401).json({ error: "missing bearer" });
+  try {
+    (req as any).auth = verifyToken(m[1]);
+    next();
+  } catch {
+    return res.status(401).json({ error: "invalid token" });
+  }
+}

--- a/apps/signaling/src/models.ts
+++ b/apps/signaling/src/models.ts
@@ -1,0 +1,8 @@
+export type RoomMode = "mesh" | "sfu";
+export interface Room {
+  id: string;
+  hostId: string;
+  mode: RoomMode;
+  createdAt: string;
+  locked?: boolean;
+}

--- a/apps/signaling/src/redis.ts
+++ b/apps/signaling/src/redis.ts
@@ -1,0 +1,6 @@
+import Redis from "ioredis";
+export const redis = new Redis(process.env.REDIS_URL);
+
+export const roomKey = (id: string) => `room:${id}`;
+export const membersKey = (id: string) => `room:${id}:members`;
+export const socketsKey = (id: string) => `room:${id}:sockets`;


### PR DESCRIPTION
## Summary
- add JWT authentication helpers for the signaling service
- add Redis client and key helpers for rooms
- define shared room types for signaling logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f9860b3c83339d3678e02f9533e0