### PR TITLE
Implement TURN REST credential generation

### DIFF
--- a/apps/signaling/src/turn.ts
+++ b/apps/signaling/src/turn.ts
@@ -1,14 +1,37 @@
 import { Request, Response } from "express";
+import crypto from "crypto";
 
-export const getTurnCredentials = async (_req: Request, res: Response) => {
-  // For now, return static TURN creds (replace with dynamic/temporary).
+function hmacSha1(key: string, content: string) {
+  return crypto.createHmac("sha1", key).update(content).digest("base64");
+}
+
+/**
+ * TURN REST API (time-limited) credentials:
+ * username = `${unixTs}:${userId}`
+ * credential = base64(hmac_sha1(shared_secret, username))
+ * expiry: client should refresh before ts
+ */
+export const getTurnCredentials = async (req: Request, res: Response) => {
+  const { userId = "anon" } = req.body ?? {};
+  const ttlSeconds = 3600; // 1 hour
+  const ts = Math.floor(Date.now() / 1000) + ttlSeconds;
+
+  const secret = process.env.TURN_SHARED_SECRET || "my-super-secret";
+  const username = `${ts}:${userId}`;
+  const credential = hmacSha1(secret, username);
+
+  const host = process.env.TURN_HOST ?? "localhost";
+  const port = process.env.TURN_PORT ?? "3478";
+  const realm = process.env.TURN_REALM ?? "example.com";
+
   const iceServers = [
-    { urls: ["stun:stun.l.google.com:19302"] },
+    { urls: [`stun:${host}:${port}`] },
     {
-      urls: ["turn:localhost:3478?transport=udp", "turn:localhost:3478?transport=tcp"],
-      username: process.env.TURN_STATIC_USERNAME || "demo",
-      credential: process.env.TURN_STATIC_CREDENTIAL || "demo"
+      urls: [`turn:${host}:${port}?transport=udp`, `turn:${host}:${port}?transport=tcp`],
+      username,
+      credential
     }
   ];
-  res.json({ iceServers });
+
+  res.json({ iceServers, ttlSeconds, realm });
 };


### PR DESCRIPTION
## Summary
- replace static TURN credentials with time-limited REST credentials generated via shared secret
- include STUN/TURN server configuration sourced from environment variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12735ef08833394424909d674fd48