### PR TITLE
Add TURN configuration defaults to signaling env example

### DIFF
--- a/apps/signaling/.env.example
+++ b/apps/signaling/.env.example
@@ -1,7 +1,10 @@
 PORT=8080
 JWT_SECRET=change_me
 REDIS_URL=redis://localhost:6379
+TURN_HOST=localhost
+TURN_PORT=3478
 TURN_REALM=example.com
+TURN_SHARED_SECRET=my-super-secret
 TURN_API_KEY=local-demo
 TURN_STATIC_USERNAME=demo
 TURN_STATIC_CREDENTIAL=demo


### PR DESCRIPTION
## Summary
- add TURN environment defaults for the signaling service example configuration
- confirm the TURN credentials endpoint is wired to the express app

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1282f54248333bab61450f9f68820