### PR TITLE
Add env configuration and Dio provider

### DIFF
--- a/apps/mobile/lib/di.dart
+++ b/apps/mobile/lib/di.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
+import 'env.dart';
+
+final dioProvider = Provider<Dio>(() {
+  return Dio(BaseOptions(baseUrl: Env.signalingBase, connectTimeout: const Duration(seconds: 5)));
+});

--- a/apps/mobile/lib/env.dart
+++ b/apps/mobile/lib/env.dart
@@ -1,4 +1,7 @@
 class Env {
-  static const signalingBase =
-      String.fromEnvironment('SIGNALING_BASE', defaultValue: 'http://localhost:8080');
+  // Replace with your LAN IP when testing on device
+  static const signalingBase = String.fromEnvironment(
+    'SIGNALING_BASE',
+    defaultValue: 'http://localhost:8080',
+  );
 }


### PR DESCRIPTION
## Summary
- add an environment configuration for the signaling base URL with documentation
- provide a Dio instance through Riverpod configured with the signaling base

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12dab3b4c8333a1688183de97e877