### PR TITLE
Add AV permission check before room actions

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'env.dart';
+import 'permissions.dart';
 import 'webrtc/signaling_client.dart';
 
 void main() {
@@ -48,8 +49,17 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   Future<void> _createRoom() async {
-    final client = ref.read(signalingClientProvider);
     final notifier = ref.read(lastMessageProvider.notifier);
+    final hasPermissions = await ensureAvPermissions();
+    if (!hasPermissions) {
+      const message = 'Camera and microphone permissions are required to create a room.';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+      return;
+    }
+
+    final client = ref.read(signalingClientProvider);
     try {
       final response = await client.createRoom(_hostController.text);
       final message = 'Created room: ${jsonEncode(response)}';
@@ -68,8 +78,17 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   Future<void> _joinRoom() async {
-    final client = ref.read(signalingClientProvider);
     final notifier = ref.read(lastMessageProvider.notifier);
+    final hasPermissions = await ensureAvPermissions();
+    if (!hasPermissions) {
+      const message = 'Camera and microphone permissions are required to join a room.';
+      notifier.state = message;
+      // ignore: avoid_print
+      print(message);
+      return;
+    }
+
+    final client = ref.read(signalingClientProvider);
     try {
       final response = await client.joinRoom(_roomController.text);
       final message = 'Joined room: ${jsonEncode(response)}';

--- a/apps/mobile/lib/permissions.dart
+++ b/apps/mobile/lib/permissions.dart
@@ -1,0 +1,6 @@
+import 'package:permission_handler/permission_handler.dart';
+
+Future<bool> ensureAvPermissions() async {
+  final statuses = await [Permission.camera, Permission.microphone].request();
+  return statuses.values.every((s) => s.isGranted);
+}


### PR DESCRIPTION
## Summary
- add an AV permission helper that requests camera and microphone access
- ensure the home page checks for AV permissions before creating or joining rooms and informs the user when they are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13c6ac87083338fe75dc167330e97