### PR TITLE
Add periodic WebRTC stats overlay

### DIFF
--- a/apps/mobile/lib/ui/call_screen.dart
+++ b/apps/mobile/lib/ui/call_screen.dart
@@ -13,10 +13,19 @@ class CallScreen extends ConsumerWidget {
 
     final tiles = <Widget>[];
     if (st.localRenderer != null) {
-      tiles.add(_VideoTile(label: "You", renderer: st.localRenderer!, mirror: true));
+      tiles.add(_VideoTile(
+        label: "You",
+        renderer: st.localRenderer!,
+        mirror: true,
+        stats: st.stats['local'],
+      ));
     }
     for (final p in st.peers) {
-      tiles.add(_VideoTile(label: p.userId, renderer: p.renderer));
+      tiles.add(_VideoTile(
+        label: p.userId,
+        renderer: p.renderer,
+        stats: st.stats[p.userId],
+      ));
     }
 
     return Scaffold(
@@ -60,7 +69,8 @@ class _VideoTile extends StatelessWidget {
   final String label;
   final RTCVideoRenderer renderer;
   final bool mirror;
-  const _VideoTile({required this.label, required this.renderer, this.mirror = false, super.key});
+  final CallStats? stats;
+  const _VideoTile({required this.label, required this.renderer, this.stats, this.mirror = false, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -68,14 +78,54 @@ class _VideoTile extends StatelessWidget {
       children: [
         RTCVideoView(renderer, mirror: mirror, objectFit: RTCVideoViewObjectFit.RTCVideoViewObjectFitContain),
         Positioned(
-          left: 12, bottom: 12,
+          left: 12,
+          bottom: 12,
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            color: Colors.black54,
-            child: Text(label, style: const TextStyle(color: Colors.white)),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            decoration: BoxDecoration(color: Colors.black54, borderRadius: BorderRadius.circular(6)),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(label, style: const TextStyle(color: Colors.white)),
+                if (stats != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      _formatStats(stats!),
+                      style: const TextStyle(color: Colors.white70, fontSize: 12),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
       ],
     );
+  }
+
+  String _formatStats(CallStats stats) {
+    final outbound = _formatKbps(stats.outboundKbps);
+    final inbound = _formatKbps(stats.inboundKbps);
+    final rtt = _formatMs(stats.rttMs);
+    final loss = _formatPercent(stats.packetLossPercent);
+    return '↑$outbound ↓$inbound kbps / RTT $rtt ms / Loss $loss%';
+  }
+
+  String _formatKbps(double? value) {
+    if (value == null) return '-';
+    if (value >= 100) return value.toStringAsFixed(0);
+    return value.toStringAsFixed(1);
+  }
+
+  String _formatMs(double? value) {
+    if (value == null) return '-';
+    if (value >= 100) return value.toStringAsFixed(0);
+    return value.toStringAsFixed(1);
+  }
+
+  String _formatPercent(double? value) {
+    if (value == null) return '-';
+    return value.toStringAsFixed(1);
   }
 }


### PR DESCRIPTION
## Summary
- capture outbound/inbound bitrate, RTT, and loss for each peer connection on a 2s interval
- store aggregated call statistics in `RoomState` and update tiles with the latest metrics
- surface a compact overlay on each CallScreen video tile showing kbps, RTT, and loss percentages

## Testing
- `dart format apps/mobile/lib/room/room_controller.dart apps/mobile/lib/ui/call_screen.dart` *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2124a15e483339829e633a81962e2