### PR TITLE
feat: add sfu service scaffold

### DIFF
--- a/apps/sfu/.env.example
+++ b/apps/sfu/.env.example
@@ -1,0 +1,3 @@
+PORT=9090
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=change_me

--- a/apps/sfu/package.json
+++ b/apps/sfu/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@apps/sfu",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "ioredis": "^5.4.1",
+    "mediasoup": "^3.14.11",
+    "socket.io": "^4.7.5",
+    "http-status-codes": "^2.3.0",
+    "zod": "^3.23.8",
+    "cors": "^2.8.5",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.12",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/sfu/tsconfig.json
+++ b/apps/sfu/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist" },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a new apps/sfu workspace package with mediasoup and supporting dependencies
- configure TypeScript build output for the new service
- document default environment values for local development

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21ed9ce8c833395241aeeb81aac8d