### PR TITLE
Add SFU service to development stack

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -21,7 +21,23 @@ services:
       - "3478:3478/udp"
       - "3478:3478/tcp"
 
+  sfu:
+    build:
+      context: ../apps/sfu
+    environment:
+      - PORT=9090
+      - REDIS_URL=redis://redis:6379
+      - JWT_SECRET=change_me
+      - ANNOUNCED_IP=127.0.0.1
+    ports:
+      - "9090:9090"
+      - "40000-49999:40000-49999/udp"
+    depends_on:
+      - redis
+
 # Notes:
+# - If you don't build with Docker yet, run the SFU app locally with pnpm
+# - For public cloud, set ANNOUNCED_IP to the machine's public IP
 # - For public cloud, add: --external-ip=<PUBLIC_IP>
 # - For TLS TURN, add certs and remove --no-tls
 # - For prod, DO NOT commit the secret; inject via .env and docker compose env_file

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm -r build",
     "dev": "pnpm -r --parallel dev",
     "dev:stack": "docker compose -f infra/docker-compose.yml up --remove-orphans",
+    "dev:sfu": "pnpm --filter @apps/sfu dev",
     "dev:signaling": "pnpm --filter @apps/signaling dev",
     "dev:admin": "pnpm --filter admin dev",
     "typecheck": "pnpm -r typecheck",


### PR DESCRIPTION
## Summary
- add an SFU service configuration to the development docker-compose stack with usage notes
- expose a pnpm script for running the SFU app locally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2227e14fc833381b578d85f20481d