### PR TITLE
Add SFU client wrapper

### DIFF
--- a/apps/mobile/lib/sfu/sfu_client.dart
+++ b/apps/mobile/lib/sfu/sfu_client.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+import 'package:socket_io_client/socket_io_client.dart' as IO;
+
+typedef CB = void Function(dynamic);
+
+class SfuClient {
+  final String baseUrl;
+  final String token;
+  IO.Socket? _io;
+
+  SfuClient(this.baseUrl, this.token);
+
+  void connect() {
+    _io = IO.io(baseUrl, {
+      'transports': ['websocket'],
+      'autoConnect': false,
+      'auth': {'token': token},
+      'forceNew': true
+    });
+    _io!.connect();
+  }
+
+  void on(String evt, CB cb) => _io?.on(evt, cb);
+
+  void emitAck(String evt, dynamic data, void Function(dynamic) cb) {
+    _io?.emitWithAck(evt, data, ack: cb);
+  }
+
+  void dispose() {
+    _io?.dispose();
+    _io = null;
+  }
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   dio: ^5.7.0
   flutter_riverpod: ^2.5.1
   socket_io_client: ^2.0.3+1
+  # (We will speak mediasoup via Socket.IO as we did in signaling.)
   uuid: ^4.5.1
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- document the existing socket_io_client dependency for mediasoup signalling
- add an SFU client helper that wraps Socket.IO connections with auth

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22ebb2a588333ae6d5277bf48a11b