### PR TITLE
Add refresh token flow for signaling service

### DIFF
--- a/apps/signaling/src/roles.ts
+++ b/apps/signaling/src/roles.ts
@@ -1,0 +1,8 @@
+export type Role = "host" | "participant";
+
+type RolePerms = Record<Role, string[]>;
+
+export const ROLE_PERMS: RolePerms = {
+  host: ["room:read", "room:write", "member:manage"],
+  participant: ["room:read"],
+};


### PR DESCRIPTION
## Summary
- mint role-based access and refresh tokens when creating or joining rooms
- store refresh tokens in Redis and add an endpoint to exchange them for new access tokens
- extend auth helpers with permission checks and define static role permissions

## Testing
- `pnpm --filter @apps/signaling typecheck` *(fails: registry access blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2395ec7b883338ca115aaf07ba727