### PR TITLE
Add request throttling to signaling server

### DIFF
--- a/apps/signaling/package.json
+++ b/apps/signaling/package.json
@@ -15,10 +15,11 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.1.5",
+    "helmet": "^7.1.2",
     "http-status-codes": "^2.3.0",
     "ioredis": "^5.4.1",
     "jsonwebtoken": "^9.0.2",
-    "helmet": "^7.1.2",
+    "slow-down": "^0.3.2",
     "socket.io": "^4.7.5",
     "zod": "^3.23.8",
     "@proto/shared": "workspace:*"
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/express-rate-limit": "^5.1.5",
     "@types/helmet": "^6.0.1",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.14.12",


### PR DESCRIPTION
## Summary
- add slow-down middleware and tighten rate limiting for the signaling API
- guard socket.io connections by tracking per-IP connection counts
- declare the new slow-down runtime dependency and express-rate-limit types for the signaling app

## Testing
- not run (pnpm 9.0.0 could not be downloaded in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e23dec7ecc8333b8ca90c25c7491c3