### PR TITLE
feat: add host controls for call screen

### DIFF
--- a/apps/mobile/lib/webrtc/signaling_socket.dart
+++ b/apps/mobile/lib/webrtc/signaling_socket.dart
@@ -19,6 +19,9 @@ class SignalingSocket {
     required void Function(Map<String, dynamic>) onMute,
     required void Function(Map<String, dynamic>) onVideoToggle,
     required void Function(Map<String, dynamic>) onAudioLevel,
+    required void Function() onMuteAll,
+    required void Function(bool locked) onRoomLocked,
+    required void Function(String? reason) onRemovedByHost,
   }) {
     _socket = IO.io(baseUrl, {
       'transports': ['websocket'],
@@ -36,6 +39,19 @@ class SignalingSocket {
     _socket!.on('mute', (data) => onMute(Map<String, dynamic>.from(data)));
     _socket!.on('videoToggle', (data) => onVideoToggle(Map<String, dynamic>.from(data)));
     _socket!.on('audioLevel', (data) => onAudioLevel(Map<String, dynamic>.from(data)));
+    _socket!.on('muteAll', (_) => onMuteAll());
+    _socket!.on('roomLocked', (data) {
+      final map = data is Map ? Map<String, dynamic>.from(data) : <String, dynamic>{};
+      final locked = map['locked'] == true;
+      onRoomLocked(locked);
+    });
+    _socket!.on('removedByHost', (data) {
+      if (data is Map) {
+        onRemovedByHost(data['reason'] as String?);
+      } else {
+        onRemovedByHost(null);
+      }
+    });
 
     _socket!.connect();
   }


### PR DESCRIPTION
## Summary
- add REST helpers for host moderation actions and track lock/removal events in the room controller
- extend the signaling socket with mute-all, room lock, and removal notifications
- update the call screen with a host overflow menu, lock banner, removal handling, and a host badge

## Testing
- not run (flutter tool unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68e23faeff108333bcb4125e86e8c7e5