### PR TITLE
Add JWT key examples and document security practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ flutter run -d <your_device>  # ensure signalingBase points to your machine IP
 - Running on an Android emulator? Use `10.0.2.2` instead of `localhost` when you need to hit services running on the host machine.
 - Testing on a physical iOS device connected to your LAN? Point `SIGNALING_BASE` to your Mac's LAN IP address so the phone can reach the signaling server.
 
+## Security
+
+- Access tokens are short lived (1 hour) with refresh tokens valid for 7 days, both stored in Redis for revocation.
+- Socket authentication relies on JWTs and enforces role/permission checks on every action.
+- Production deployments must terminate TLS; only HTTPS/WSS traffic is accepted.
+- TURN uses shared-secret authentication to issue time-limited credentials.
+- Optional end-to-end encryption can be toggled per room by the host, exchanging room keys and enabling frame-level encryption when supported.
+- Rotate signing keys by prepending new entries to `JWT_KEYS`, redeploying, then removing old keys after clients refresh.
+
 ## Production Notes
 
 - **JWT lifetime:** In production deployments the signaling service now defaults to a five-minute JWT and reports the TTL in room create/join responses. Clients should request a fresh token whenever they reconnect so expired credentials do not block access.

--- a/apps/sfu/.env.example
+++ b/apps/sfu/.env.example
@@ -1,3 +1,4 @@
 PORT=9090
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=change_me
+JWT_KEYS=[{"kid":"k1","secret":"REPLACE_WITH_LONG_RANDOM"}]

--- a/apps/signaling/.env.example
+++ b/apps/signaling/.env.example
@@ -1,5 +1,6 @@
 PORT=8080
 JWT_SECRET=change_me
+JWT_KEYS=[{"kid":"k1","secret":"REPLACE_WITH_LONG_RANDOM"}]
 JWT_TTL=5m
 REDIS_URL=redis://localhost:6379
 TURN_HOST=localhost


### PR DESCRIPTION
## Summary
- add JWT key arrays to the signaling and SFU environment examples
- document security architecture and operational guidance in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e290fe43e483339a1507e1f5872895