### PR TITLE
Add Flutter MainActivity using v2 embedding

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/example/mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/mobile/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.example.mobile
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()


### PR DESCRIPTION
## Summary
- add a Kotlin MainActivity that uses Flutter's v2 Android embedding so the Android build can succeed again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e565b03f0483338c6b69e9d1f02bdf