### PR TITLE
Fix Riverpod provider signature for Dio

### DIFF
--- a/apps/carconnect/lib/di.dart
+++ b/apps/carconnect/lib/di.dart
@@ -2,6 +2,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dio/dio.dart';
 import 'env.dart';
 
-final dioProvider = Provider<Dio>(() {
-  return Dio(BaseOptions(baseUrl: Env.signalingBase, connectTimeout: const Duration(seconds: 5)));
+final dioProvider = Provider<Dio>((ref) {
+  return Dio(
+    BaseOptions(
+      baseUrl: Env.signalingBase,
+      connectTimeout: const Duration(seconds: 5),
+    ),
+  );
 });


### PR DESCRIPTION
## Summary
- update the Dio provider to accept the required ProviderRef parameter for Riverpod
- keep the Dio construction and base options formatting consistent

## Testing
- `flutter analyze lib/di.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68e683c7d9c083339c0b009559c2aaca