### PR TITLE
Align Android Kotlin JVM target with Java

### DIFF
--- a/apps/carconnect/android/app/build.gradle
+++ b/apps/carconnect/android/app/build.gradle
@@ -39,6 +39,15 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 flutter {


### PR DESCRIPTION
## Summary
- align the Android Gradle configuration so Kotlin compiles to the same JVM target as Java
- ensure the Flutter app builds without JVM target compatibility errors

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e68cfd974c8333842f2b01dc70b50a